### PR TITLE
fix: correct sensor ID key when fetching PM2.5 sensors

### DIFF
--- a/air-quality-project/src/fetch_openaq.py
+++ b/air-quality-project/src/fetch_openaq.py
@@ -20,7 +20,11 @@ def get_pm25_sensors(limit=50):
     if response.status_code != 200:
         raise Exception(f"Failed to fetch sensor list: {response.text}")
     results = response.json().get("results", [])
-    return [r["sensorsId"] for r in results if "sensorsId" in r]
+    # API responses use the key `sensorId` to identify each sensor.
+    # The previous implementation looked for `sensorsId`, which never
+    # exists and resulted in an empty sensor list.  Fetch the correct key
+    # and guard against missing values.
+    return [r["sensorId"] for r in results if r.get("sensorId") is not None]
 
 # 2. Get daily average values for a given sensor ID
 def get_daily_values(sensor_id, limit=365):


### PR DESCRIPTION
## Summary
- use the proper `sensorId` field from the OpenAQ API when gathering sensor IDs
- handle missing sensor IDs gracefully to avoid crashes

## Testing
- `python -m py_compile air-quality-project/src/fetch_openaq.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73e5cfae083308fa4e71a537267ed