### PR TITLE
Add root Streamlit dashboard to navigate project apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,14 @@ Analytics-ETL-Dashboards/
 │   ├── outputs/ (visualizations)
 │   └── src/
 │
+├── streamlit_dashboard.py (combined dashboard)
 └── README.md
+```
+
+Launch the unified Streamlit interface to switch between all dashboards with:
+
+```bash
+streamlit run streamlit_dashboard.py
 ```
 
 

--- a/streamlit_dashboard.py
+++ b/streamlit_dashboard.py
@@ -1,0 +1,39 @@
+import os
+import runpy
+from contextlib import contextmanager
+
+import streamlit as st
+
+st.set_page_config(page_title="Analytics Dashboards", layout="wide")
+# Prevent sub-dashboards from resetting page config
+st.set_page_config = lambda *args, **kwargs: None
+
+@contextmanager
+def run_from(path: str):
+    """Temporarily change directory to run a Streamlit script."""
+    prev_cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
+
+st.sidebar.title("Dashboards")
+dashboard = st.sidebar.radio(
+    "Select a dashboard",
+    (
+        "Air Quality",
+        "World Happiness",
+        "Global Unemployment",
+    ),
+)
+
+if dashboard == "Air Quality":
+    with run_from("air-quality-project"):
+        runpy.run_path("streamlit_dashboard.py", run_name="__main__")
+elif dashboard == "World Happiness":
+    with run_from("World-Happiness"):
+        runpy.run_path("streamlit_dashboard.py", run_name="__main__")
+else:
+    with run_from("Global-Unemployment"):
+        runpy.run_path("streamlit_dashboard.py", run_name="__main__")


### PR DESCRIPTION
## Summary
- Add `streamlit_dashboard.py` at repository root to switch between Air Quality, World Happiness, and Global Unemployment dashboards from a single Streamlit interface.
- Document new unified dashboard in README with run instructions.

## Testing
- `python -m py_compile streamlit_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7402f705c8330ae8ba97237dd5327