### PR TITLE
feat: unify streamlit dashboards with absolute path dispatcher

### DIFF
--- a/Global-Unemployment/streamlit_dashboard.py
+++ b/Global-Unemployment/streamlit_dashboard.py
@@ -3,9 +3,11 @@
 import streamlit as st
 import pandas as pd
 import plotly.express as px
+from pathlib import Path
 
 # Load cleaned data
-df = pd.read_csv("data/cleaned/cleaned_unemployment.csv")
+BASE = Path(__file__).resolve().parent
+df = pd.read_csv(BASE / "data" / "cleaned" / "cleaned_unemployment.csv")
 df["year"] = df["year"].astype(int)
 
 # Streamlit page setup

--- a/README.md
+++ b/README.md
@@ -107,8 +107,21 @@ Analytics-ETL-Dashboards/
 │   ├── outputs/ (visualizations)
 │   └── src/
 │
+├── streamlit_dashboard.py (combined dashboard)
+├── requirements.txt
 └── README.md
 ```
+
+## Setup
+
+Install dependencies from the consolidated requirements file and launch the unified Streamlit interface:
+
+```bash
+pip install -r requirements.txt
+streamlit run streamlit_dashboard.py
+```
+
+Use the sidebar to switch between the Air Quality, World Happiness, and Global Unemployment dashboards.
 
 
 

--- a/World-Happiness/streamlit_dashboard.py
+++ b/World-Happiness/streamlit_dashboard.py
@@ -3,9 +3,11 @@
 import streamlit as st
 import pandas as pd
 import plotly.express as px
+from pathlib import Path
 
 # Load data
-df = pd.read_csv("data/cleaned/cleaned_happiness.csv")
+BASE = Path(__file__).resolve().parent
+df = pd.read_csv(BASE / "data" / "cleaned" / "cleaned_happiness.csv")
 df["year"] = df["year"].astype(int)
 
 st.set_page_config(layout="wide")

--- a/air-quality-project/streamlit_dashboard.py
+++ b/air-quality-project/streamlit_dashboard.py
@@ -1,9 +1,11 @@
 import streamlit as st
 import pandas as pd
 import plotly.express as px
+from pathlib import Path
 
 # Load data
-df = pd.read_csv("data/processed/pm25_geo_enriched.csv")
+BASE = Path(__file__).resolve().parent
+df = pd.read_csv(BASE / "data" / "processed" / "pm25_geo_enriched.csv")
 df["date"] = pd.to_datetime(df["date"])
 df = df.dropna(subset=["pm25", "city", "country"])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+pandas
+plotly
+requests

--- a/streamlit_dashboard.py
+++ b/streamlit_dashboard.py
@@ -1,0 +1,20 @@
+import runpy
+from pathlib import Path
+
+import streamlit as st
+
+st.set_page_config(page_title="Analytics Dashboards", layout="wide")
+# Prevent sub-dashboards from resetting page config
+st.set_page_config = lambda *args, **kwargs: None
+
+BASE = Path(__file__).resolve().parent
+DASHBOARD_PATHS = {
+    "Air Quality": BASE / "air-quality-project" / "streamlit_dashboard.py",
+    "World Happiness": BASE / "World-Happiness" / "streamlit_dashboard.py",
+    "Global Unemployment": BASE / "Global-Unemployment" / "streamlit_dashboard.py",
+}
+
+st.sidebar.title("Dashboards")
+dashboard = st.sidebar.radio("Select a dashboard", list(DASHBOARD_PATHS.keys()))
+
+runpy.run_path(str(DASHBOARD_PATHS[dashboard]), run_name="__main__")


### PR DESCRIPTION
## Summary
- add root streamlit entrypoint that dispatches to each dashboard by absolute path with sidebar selector
- load datasets in sub-dashboards relative to their scripts and consolidate dependencies into root requirements
- document consolidated requirements in README

## Testing
- `python -m py_compile streamlit_dashboard.py air-quality-project/streamlit_dashboard.py World-Happiness/streamlit_dashboard.py Global-Unemployment/streamlit_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7402f705c8330ae8ba97237dd5327